### PR TITLE
Tests for thing-form component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+
+
+.DS_Store
+

--- a/app/locations/show/template.hbs
+++ b/app/locations/show/template.hbs
@@ -1,4 +1,6 @@
-<h2>{{model.name}}</h2>
+<h2><span class="location-name">{{model.name}}</span>
+{{#link-to "things.new" class="btn btn-sm btn-primary"}}New{{/link-to}}
+</h2>
 <div class="row">
   {{#each model.things as |thing|}}
     <div class="col-md-3">

--- a/tests/acceptance/locations-test.js
+++ b/tests/acceptance/locations-test.js
@@ -29,7 +29,7 @@ test('visiting /locations with exactly 1 location', function(assert) {
 
   andThen(function() {
     assert.equal(currentURL(), '/locations/1', 'Was not redirected to only location.');
-    assert.equal(find('h2').text(), 'Location 1');
+    assert.equal(find('.location-name').text(), 'Location 1');
   });
 });
 
@@ -41,5 +41,23 @@ test('visiting /locations with 2 location', function(assert) {
   andThen(function() {
     assert.equal(currentURL(), '/locations', 'Should not be redirected');
     assert.equal(find('A:contains("Location")').length, 2);
+  });
+});
+
+test('clicking New button navigates to /things/new', function(assert) {
+  server.create('location');
+
+  const locationUrl = '/locations/1';
+  visit(locationUrl);
+
+  andThen(function() {
+    assert.equal(find('.location-name').text(), 'Location 1');
+    assert.equal(find('.btn-primary').text(), 'New');
+
+    click('.btn-primary');
+
+    andThen(function() {
+      assert.equal(currentURL(), '/things/new', 'Should have redirected');
+    });
   });
 });

--- a/tests/integration/components/thing-form/component-test.js
+++ b/tests/integration/components/thing-form/component-test.js
@@ -14,13 +14,11 @@ test('it renders', function(assert) {
 });
 
 test('it sets input correctly', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });"
-
   const thing = { name: 'myThing' };
+
   this.set('model', thing);
 
-  this.render(hbs`{{thing-form}}`);
+  this.render(hbs`{{thing-form thing=model}}`);
 
-  assert.equal(this.$('input').text().trim(), thing.name);
+  assert.equal(this.$('input').val().trim(), thing.name);
 });

--- a/tests/integration/components/thing-form/component-test.js
+++ b/tests/integration/components/thing-form/component-test.js
@@ -6,19 +6,21 @@ moduleForComponent('thing-form', 'Integration | Component | thing form', {
 });
 
 test('it renders', function(assert) {
+  this.render(hbs`{{thing-form}}`);
+
+  assert.equal(this.$('label').text().trim(), 'Name:');
+  assert.equal(this.$('.btn.btn-success').text().trim(), 'Save');
+  assert.equal(this.$('.btn.btn-danger').text().trim(), 'Cancel');
+});
+
+test('it sets input correctly', function(assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });"
 
+  const thing = { name: 'myThing' };
+  this.set('model', thing);
+
   this.render(hbs`{{thing-form}}`);
 
-  assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:"
-  this.render(hbs`
-    {{#thing-form}}
-      template block text
-    {{/thing-form}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(this.$('input').text().trim(), thing.name);
 });

--- a/tests/integration/components/thing-form/component-test.js
+++ b/tests/integration/components/thing-form/component-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -14,7 +15,7 @@ test('it renders', function(assert) {
 });
 
 test('it sets input correctly', function(assert) {
-  const thing = { name: 'myThing' };
+  const thing = Ember.Object.create( { name: "myThing" } );
 
   this.set('model', thing);
 


### PR DESCRIPTION
This PR currently does the following...

**thing-form component**
* Tests are now working
    * More tests will be required as we finish out this functionality

**Locations/show**
* Added "New" button on the `/location/show` template
    - modified corresponding tests
* Added new test to ensure clicking the "New" button redirects to the `/things/new` route

**What remains on create a new thing form**

- [ ] Cancel button returns to Thing's location
- [ ] input other properties of a Thing
- [ ] Save button saves new Thing
- [ ] ??

